### PR TITLE
Add dashboard link to startup log

### DIFF
--- a/app.py
+++ b/app.py
@@ -273,4 +273,7 @@ def limit_order():
 if __name__ == "__main__":
     port = int(os.getenv("API_PORT", 5020))
     logger.info(f"Starting API service on port {port}")
+    logger.info(
+        "Dashboard available at http://localhost:%s/dashboard", port
+    )
     app.run(host="0.0.0.0", port=port)


### PR DESCRIPTION
## Summary
- log a startup message indicating the dashboard URL

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'dotenv')*

------
https://chatgpt.com/codex/tasks/task_e_68446fd35148832ca4b142eae42a2edf