### PR TITLE
Update dashboard with auto scripts

### DIFF
--- a/routes/dashboard.py
+++ b/routes/dashboard.py
@@ -2,7 +2,12 @@ import os
 from flask import Blueprint, render_template
 from sqlalchemy import create_engine
 from sqlalchemy.orm import sessionmaker, joinedload
-from models import CriptoThreshold
+from models import (
+    CriptoThreshold,
+    DailyPurchaseConfig,
+    AutoBuyQuota,
+    UserCredentials,
+)
 
 DB_HOST = os.getenv("DB_HOST")
 DB_NAME = os.getenv("DB_NAME")
@@ -14,37 +19,87 @@ dashboard_bp = Blueprint("dashboard", __name__)
 
 @dashboard_bp.route('/dashboard')
 def dashboard():
-    # Configuração da conexão com o banco de dados
+    # Database connection setup
     SQLALCHEMY_DATABASE_URL = f"postgresql://{DB_USER}:{DB_PASSWORD}@{DB_HOST}:{DB_PORT}/{DB_NAME}"
     engine = create_engine(SQLALCHEMY_DATABASE_URL)
     SessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)
     db_session = SessionLocal()
 
-    # Consulta aos dados de CriptoThreshold com os relacionamentos
+    # Query CriptoThreshold data with related objects
     data = (
         db_session.query(CriptoThreshold)
         .options(joinedload(CriptoThreshold.email), joinedload(CriptoThreshold.cripto))
         .all()
     )
 
-    # Estruturação dos dados para o template
-    thresholds = [{
-        "email": t.email.email,
-        "symbol": t.cripto.symbol,
-        "threshold": float(t.threshold),
-        "greaterThanCurrent": t.greaterThanCurrent
-    } for t in data]
+    # Prepare data for the template
+    thresholds = [
+        {
+            "email": t.email.email,
+            "symbol": t.cripto.symbol,
+            "threshold": float(t.threshold),
+            "greaterThanCurrent": t.greaterThanCurrent,
+        }
+        for t in data
+    ]
 
-    # Caminho para o arquivo de log
+    # Daily buy configuration
+    daily_data = (
+        db_session.query(DailyPurchaseConfig)
+        .options(joinedload(DailyPurchaseConfig.user))
+        .all()
+    )
+    daily_configs = [
+        {
+            "email": d.user.email,
+            "symbol": d.crypto_symbol,
+            "amount_brl": float(d.amount_brl),
+        }
+        for d in daily_data
+    ]
+    dip_hour = os.getenv("DIP_HOUR_UTC", "4")
+
+    # Auto sell quotas
+    quota_data = (
+        db_session.query(AutoBuyQuota)
+        .options(joinedload(AutoBuyQuota.user))
+        .all()
+    )
+    auto_sell_quotas = [
+        {
+            "email": q.user.email,
+            "symbol": q.crypto_symbol,
+            "limit": float(q.quota_limit_brl),
+            "used": float(q.quota_used_brl),
+        }
+        for q in quota_data
+    ]
+
+    # Log file paths
     basedir = os.path.abspath(os.path.dirname(__file__))
-    log_path = os.getenv("LOG_PATH", os.path.join(basedir, "..", "logs", "send-email.log"))
+    log_dir = os.getenv("LOG_DIR", os.path.join(basedir, "..", "logs"))
+    email_log_path = os.getenv("LOG_PATH", os.path.join(log_dir, "send-email.log"))
+    daily_log_path = os.path.join(log_dir, "daily-buy.log")
+    auto_sell_log_path = os.path.join(log_dir, "auto-sell.log")
 
-    # Leitura dos últimos 50 logs
-    if os.path.exists(log_path):
-        with open(log_path, 'r') as f:
-            logs = "\n".join(f.readlines()[-50:])
-    else:
-        logs = "Log file not found."
+    def tail_log(path, lines=50):
+        if os.path.exists(path):
+            with open(path, "r") as f:
+                return "\n".join(f.readlines()[-lines:])
+        return "Log file not found."
 
-    # Renderização do template com os dados
-    return render_template("dashboard.html", thresholds=thresholds, logs=logs)
+    logs = tail_log(email_log_path)
+    daily_logs = tail_log(daily_log_path)
+    auto_sell_logs = tail_log(auto_sell_log_path)
+
+    # Render the template with data
+    return render_template(
+        "dashboard.html",
+        thresholds=thresholds,
+        logs=logs,
+        daily_configs=daily_configs,
+        dip_hour=dip_hour,
+        daily_logs=daily_logs,
+        auto_sell_quotas=auto_sell_quotas,
+        auto_sell_logs=auto_sell_logs,
+    )

--- a/templates/dashboard.html
+++ b/templates/dashboard.html
@@ -2,11 +2,31 @@
 <html>
   <head>
     <title>Dashboard</title>
+    <style>
+      body {
+        background-color: #000;
+        color: #FFD700;
+        font-family: Arial, sans-serif;
+        margin: 0;
+        padding: 20px;
+      }
+      h1, h2, h3 {
+        color: #FFD700;
+      }
+      pre {
+        background-color: #111;
+        border: 1px solid #FFD700;
+        padding: 10px;
+        overflow-x: auto;
+      }
+      ul { list-style-type: none; padding: 0; }
+      li { padding: 4px 0; }
+    </style>
   </head>
   <body>
     <h1>Coin-Alert Dashboard</h1>
 
-    <h2>Cripto Thresholds</h2>
+    <h2>Crypto Thresholds</h2>
     <ul>
       {% for t in thresholds %}
       <li>
@@ -16,7 +36,26 @@
       {% endfor %}
     </ul>
 
-    <h2>Most recente logs</h2>
+    <h2>Daily Buy</h2>
+    <p>Daily purchases occur at {{ dip_hour }}:00 UTC.</p>
+    <ul>
+      {% for c in daily_configs %}
+      <li>{{ c.email }} - {{ c.symbol }} - R${{ c.amount_brl }}</li>
+      {% endfor %}
+    </ul>
+    <h3>Daily Buy Logs</h3>
+    <pre>{{ daily_logs }}</pre>
+
+    <h2>Auto Sell</h2>
+    <ul>
+      {% for q in auto_sell_quotas %}
+      <li>{{ q.email }} - {{ q.symbol }} - Limit {{ q.limit }} BRL - Used {{ q.used }} BRL</li>
+      {% endfor %}
+    </ul>
+    <h3>Auto Sell Logs</h3>
+    <pre>{{ auto_sell_logs }}</pre>
+
+    <h2>Most Recent Email Logs</h2>
     <pre>{{ logs }}</pre>
   </body>
 </html>


### PR DESCRIPTION
## Summary
- display auto sell and daily buy data on the dashboard
- show recent logs for daily-buy and auto-sell scripts
- translate dashboard UI to English and add black/yellow styling

## Testing
- `pip install -r requirements.txt`
- `pytest -q` *(fails: network unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68447282b650832c8f91be9e6eb88b82